### PR TITLE
Feat: [2주차] 장우진 PR

### DIFF
--- a/jwj/week02/[15683] 감시.py
+++ b/jwj/week02/[15683] 감시.py
@@ -1,0 +1,75 @@
+import sys, copy
+input = sys.stdin.readline
+
+# 최악의 경우 계산
+# 전체 지도 크기 : 64
+# CCTV 최대 개수 : 8개
+
+# 따라서 모든 경우를 고려한 순열/조합 라이브러리로는 절대 해결 불가능
+
+modes = [
+    [],                                           # 0번
+    [(0, ), (1, ), (2, ), (3, )],                 # 1번
+    [(1, 3), (0, 2)],                             # 2번
+    [(0, 1), (1, 2), (2, 3), (3, 0)],             # 3번
+    [[3, 0, 1], [0, 1, 2], [1, 2, 3], [2, 3, 0]], # 4번
+    [[0, 1, 2, 3]],                               # 5번  
+]
+
+# 북 동 남 서
+dy = [-1, 0, 1, 0]
+dx = [0, 1, 0, -1]
+
+result = float('inf') # 사각지대 최소 영역 크기
+N, M = map(int, input().split())
+board = [list(map(int, input().split())) for _ in range(N)]
+
+# cctv 위치 정보 및 번호 저장
+cctvs = []
+for i in range(N):
+    for j in range(M):
+        if board[i][j] not in [0, 6]:
+            cctvs.append([i, j, board[i][j]])
+
+# cctv마다 탐색할 수 있는 범위가 따로 있으므로
+def search(maps, mode, y, x):
+    for i in mode:
+        ny = y
+        nx = x
+        while True:
+            ny += dy[i]
+            nx += dx[i]
+                
+            # 영역을 벗어나는 경우
+            if ny < 0 or ny >= N or nx < 0 or nx >= M:
+                break
+            
+            # 영역 안에 있는 경우
+            if 0 <= ny < N and 0 <= nx < M:
+                # 벽이면 중단
+                if maps[ny][nx] == 6:
+                    break
+                # 빈 칸이면 cctv 체크 가능 영역
+                if maps[ny][nx] == 0:
+                    maps[ny][nx] = -1
+
+def process(depth, maps):
+    global result
+    # 현재 주어진 지도 정보에서 CCTV 개수만큼 다 돌렸다면(종료)
+    if depth == len(cctvs):
+        cnt = 0
+        for row in maps:
+            cnt += row.count(0)
+        result = min(result, cnt)
+        return
+    
+    cb = copy.deepcopy(maps)
+    y, x, cn = cctvs[depth]
+    # CCTV 번호별 탐색 가능 방향만큼
+    for mode in modes[cn]:
+        search(cb, mode, y, x)
+        process(depth+1, cb)
+        cb = copy.deepcopy(maps)
+
+process(0, board)
+print(result)

--- a/jwj/week02/[15683] 감시.py
+++ b/jwj/week02/[15683] 감시.py
@@ -1,3 +1,11 @@
+'''
+* Author    : Jang Woo Jin
+* Date      : 2024.10.11(Fri)
+* Runtime   : 2452 ms
+* Memory    : 31684 KB
+* Algorithm : simulation
+'''
+
 import sys, copy
 input = sys.stdin.readline
 

--- a/jwj/week02/[16927] 배열 돌리기.py
+++ b/jwj/week02/[16927] 배열 돌리기.py
@@ -1,0 +1,46 @@
+'''
+* Author    : Jang Woo Jin
+* Date      : 2024.10.07(Mon)
+* Runtime   : 288 ms
+* Memory    : 111880 KB (PyPy3)
+* Algorithm : implementation
+'''
+
+import sys
+input = sys.stdin.readline
+
+N, M, R = map(int, input().split())
+array = [list(map(int, input().split())) for _ in range(N)]
+
+# 내/외부 회전 수 규칙 파악(다시 원래대로 돌아오기까지)
+turn_cnt = []
+for i in range(min(N, M) // 2):
+    turn_cnt.append(2 * ((N - 2 * i) + (M - 2 * i)) - 4)
+    
+# 반시계 방향 회전
+# 전체를 돌리는 것이 아닌 N, M 최솟값 중 절반 범위까지만
+for i in range(min(N, M) // 2):
+    for j in range(R % turn_cnt[i]):
+        first = array[i][i]
+
+        # 위쪽 변
+        for k in range(i+1, M-i):
+            array[i][k-1] = array[i][k]
+        
+        # 오른쪽 변
+        for k in range(i+1, N-i):
+            array[k-1][M-1-i] = array[k][M-1-i]
+        
+        # 아래쪽 변
+        for k in range(i+1, M-i):
+            array[N-1-i][M-k] = array[N-1-i][M-1-k]
+             
+        # 왼쪽 변
+        for k in range(i+1, N-i):
+            array[N-k][i] = array[N-1-k][i]     
+        
+        # 맨 처음 빼놨던 값을 회전 마지막 결과에 포함시켜야 함
+        array[i+1][i] = first
+            
+for row in array:
+    print(*row)

--- a/jwj/week02/[22942] 데이터 체커.py
+++ b/jwj/week02/[22942] 데이터 체커.py
@@ -1,0 +1,33 @@
+'''
+* Author    : Jang Woo Jin
+* Date      : 2024.10.04(Fri)
+* Runtime   : 820 ms
+* Memory    : 84508 KB
+* Algorithm : data structure
+'''
+
+import sys
+input = sys.stdin.readline
+
+N = int(input())
+circles = []
+for i in range(N):
+    a, b = map(int, input().split())
+    circles.append([a-b, i])
+    circles.append([a+b, i])
+circles.sort()
+
+stack = []
+for circle in circles:
+    if not stack:
+        stack.append(circle)
+    else:
+        if stack[-1][1] == circle[1]:
+            stack.pop()
+        else:
+            stack.append(circle)
+
+if stack:
+    print("NO")
+else:
+    print("YES")

--- a/jwj/week02/[5639] 이진 검색 트리.py
+++ b/jwj/week02/[5639] 이진 검색 트리.py
@@ -1,0 +1,35 @@
+'''
+* Author    : Jang Woo Jin
+* Date      : 2024.10.11(Fri)
+* Runtime   : 1924 ms
+* Memory    : 33548 KB
+* Algorithm : recursive, tree
+'''
+
+import sys
+sys.setrecursionlimit(10**6)    # 최대 재귀 깊이 설정
+input = sys.stdin.readline
+
+# 트리 전위 순회 순서 : 루트 → 왼쪽 → 오른쪽
+# 트리 후위 순회 순서 : 왼쪽 → 오른쪽 → 루트
+
+tree = []
+while True:
+    try:
+        tree.append(int(input()))
+    except:
+        break
+
+def search(start, end):
+    if start > end:
+        return
+    ridx = end + 1
+    for idx in range(start+1, end+1):   # 루트를 제외한 범위 탐색
+        if tree[start] < tree[idx]:
+            ridx = idx
+            break
+    search(start+1, ridx-1)    # 왼쪽 서브트리
+    search(ridx, end)          # 오른쪽 서브트리
+    print(tree[start])         # 루트 노드
+
+search(0, len(tree) - 1)

--- a/jwj/week02/[9934] 완전 이진 트리.py
+++ b/jwj/week02/[9934] 완전 이진 트리.py
@@ -1,0 +1,30 @@
+'''
+* Author    : Jang Woo Jin
+* Date      : 2024.10.04(Fri)
+* Runtime   : 32 ms
+* Memory    : 31120 KB
+* Algorithm : recursive, tree
+'''
+
+import sys
+sys.setrecursionlimit(10**6)
+input = sys.stdin.readline
+
+K = int(input())
+tree = [[] for _ in range(K)]
+building = list(map(int, input().split()))
+
+def func(start, end, depth):
+    if start == end:
+        tree[depth].append(building[start])
+        return
+    mid = (start + end) // 2
+    tree[depth].append(building[mid])
+    func(start, mid-1, depth+1)
+    func(mid+1, end, depth+1)
+
+func(0, len(building)-1, 0)
+for i in tree:
+    for j in i:
+        print(j, end=" ")
+    print()


### PR DESCRIPTION
- [x] **데이터 체커(Gold 4)**

> 원의 중심 좌표로부터 반지름 r만큼 떨어진 x축 위에 존재하는 2개의 좌표와 인덱스를 기록합니다. 인덱스까지 기록하는 이유는 원이 다른 원과 겹치면 안 된다는 2번 조건을 위해서입니다. 좌표 하나하나 스택에 넣고 스택의 마지막 원소의 인덱스와 for문을 통해 순회하는 인덱스를 비교하여 일치하는 경우에만 `pop()` 연산을 처리하고 만약 일치하지 않는 경우라면 추가해줍니다.
>
> for문을 돌리고 나서 스택의 최종 결과물을 보았을 때 만약 남아있는 원소가 존재한다면 결국 하나라도 겹친다는 뜻이 되므로 각각의 조건에 맞는 출력을 하도록 했습니다.

- [x] **이진 검색 트리(Gold 4)** 

> 문제에서 주어진 입력 순서는 전위 순서로 (중앙 → 왼쪽 → 오른쪽) 순서입니다. 또한 이진 검색 트리는 부모 노드가 왼쪽 자식 노드보다 크면서 오른쪽 자식 노드보다는 작아야 합니다. 따라서 중앙 노드를 기준으로 이후 인덱스부터 시작하여 for문을 돌려 왼쪽 서브 트리와 오른쪽 서브 트리를 구분하는 작업을 거치면서 마지막으로 start가 end보다 커지는 시점까지 재귀를 수행하는 방식으로 해결할 수 있었습니다.

- [x] **완전 이진 트리(Silver 5)**

> 상근이가 어떤 순서로 도시를 방문했는지가 나와 있는데 힌트의 핵심을 말하자면 결국 트리의 순회는 중위 순회라는 것을 알 수 있습니다. 트리의 순회를 기반으로 재귀를 수행하는 방식으로 해결할 수 있었습니다.

- [x] **배열 돌리기 2(Gold 5)**

> 시뮬레이션 문제로 이전 문제인 배열 돌리기 1보다 입출력 조건이 좀 더 까다로워진 형태의 문제였습니다. 제한 조건으로 주어지는 값의 범위가 더 커지게 된 만큼 이 모든 과정을 선형 탐색으로 해결하기엔 무리가 있다고 판단해서 시간을 줄일 수 있는 방법을 고민했습니다. 가장자리와 내부의 배열을 돌릴 때, 얼만큼 돌려야 다시 원 상태로 돌아올 수 있을지 규칙성을 파악했고 나머지 정리를 이용하여 나머지값만큼만 배열을 회전시키면 될 것이라고 생각하여 해당 방식으로 문제를 해결할 수 있었습니다.

- [x] **감시 (Gold 3)**

> 삼성 SW 코딩테스트에서 자주 보이는 시뮬레이션 문제였습니다. 난이도가 G3이라 초반에 겁을 먹긴 했으나 문제의 요구 사항을 정확하게 파악한다면 그대로 구현하면 되는 비교적 간단한 문제였습니다. 
>
> 문제에서 주어진 CCTV의 탐색 방향으로 나올 수 있는 모든 조건을 미리 선언하고 주어진 2차원 배열을 깊은 복사를 활용하여 매번 수행할 수 있는 CCTV 탐색 상황에서의 사각지대를 계산하면 됩니다.
>
> 삼성 SW 코딩테스트의 구현이나 시뮬레이션의 경우 순열/조합 라이브러리를 사용하는 문제가 종종 있었는데 이 문제는 해당 라이브러리를 사용하기 어렵다고 생각했습니다. 
>
> `Big-O 표기법`에 의해 최악의 경우를 계산해보면 2차원 사무실 배열의 전체 크기는 64가 되고 CCTV의 개수를 최대 8개라고 가정하고 조합론을 사용해 계산을 수행하면 10억이 훨씬 넘는 어마어마한 경우의 수를 보게 되는데 여기에 CCTV의 방향에 따른 탐색 조건까지 추가로 고려하면 일찍이 안 된다는 것을 알 수 있습니다.