### PR TITLE
Feat: [6주차] 장우진 PR

### DIFF
--- a/jwj/week06/[1749] 점수따먹기.py
+++ b/jwj/week06/[1749] 점수따먹기.py
@@ -1,6 +1,6 @@
 '''
 * Author    : Jang Woo Jin
-* Date      : 2024.11.08(Mon)
+* Date      : 2024.11.08(Fri)
 * Runtime   : 3744 ms
 * Memory    : 111028 KB (PyPy3)
 * Algorithm : Dynamic Programming

--- a/jwj/week06/[1749] 점수따먹기.py
+++ b/jwj/week06/[1749] 점수따먹기.py
@@ -1,0 +1,28 @@
+'''
+* Author    : Jang Woo Jin
+* Date      : 2024.11.08(Mon)
+* Runtime   : 3744 ms
+* Memory    : 111028 KB (PyPy3)
+* Algorithm : Dynamic Programming
+'''
+
+import sys
+input = sys.stdin.readline
+
+N, M = map(int, input().split())
+
+board = [list(map(int, input().split())) for _ in range(N)]
+prefix_sum = [[0] * (M + 1) for _ in range(N + 1)]
+INF = -int(1e8)
+
+for i in range(1, N+1):
+    for j in range(1, M+1):
+        prefix_sum[i][j] = prefix_sum[i-1][j] + prefix_sum[i][j-1] - prefix_sum[i-1][j-1] + board[i-1][j-1]
+
+ans = INF
+for y1 in range(1, N+1):
+    for x1 in range(1, M+1):
+        for y2 in range(y1, N+1):
+            for x2 in range(x1, M+1):
+                ans = max(ans, prefix_sum[y2][x2] - prefix_sum[y2][x1 - 1] - prefix_sum[y1 - 1][x2] + prefix_sum[y1 - 1][x1 - 1])
+print(ans)

--- a/jwj/week06/[1912] 연속합.py
+++ b/jwj/week06/[1912] 연속합.py
@@ -1,0 +1,17 @@
+'''
+* Author    : Jang Woo Jin
+* Date      : 2024.11.08(Fri)
+* Runtime   : 88 ms
+* Memory    : 38828 KB
+* Algorithm : Dynamic Programming
+'''
+
+import sys
+input = sys.stdin.readline
+
+n = int(input())
+li = list(map(int, input().strip().split()))
+
+for i in range(1, n):
+    li[i] = max(li[i], li[i-1] + li[i])
+print(max(li))

--- a/jwj/week06/[1932] 정수 삼각형.py
+++ b/jwj/week06/[1932] 정수 삼각형.py
@@ -1,0 +1,29 @@
+'''
+* Author    : Jang Woo Jin
+* Date      : 2024.11.08(Fri)
+* Runtime   : 116 ms
+* Memory    : 41688 KB
+* Algorithm : Dynamic Programming
+'''
+
+import sys
+input = sys.stdin.readline
+
+N = int(input())
+triangle = [list(map(int, input().split())) for _ in range(N)]
+dp = [[0] * N for _ in range(N)]
+dp[0][0] = triangle[0][0]
+
+for i in range(1, N):
+    dp[i][0] += dp[i-1][0] + triangle[i][0]
+    dp[i][i] += dp[i-1][i-1] + triangle[i][i]
+
+for i in range(2, N):
+    for j in range(1, i):
+        dp[i][j] = triangle[i][j] + max(dp[i-1][j-1], dp[i-1][j])
+
+result = 0
+for i in range(N):
+    MAX = max(dp[i])
+    result = max(result, MAX)
+print(result)

--- a/jwj/week06/[2167] 2차원 배열의 합.py
+++ b/jwj/week06/[2167] 2차원 배열의 합.py
@@ -1,0 +1,24 @@
+'''
+* Author    : Jang Woo Jin
+* Date      : 2024.11.08(Fri)
+* Runtime   : 3472 ms
+* Memory    : 117032 KB (PyPy3)
+* Algorithm : Implementation
+'''
+
+import sys
+
+N, M = map(int, sys.stdin.readline().split())
+arr = []
+for i in range(N):
+    arr.append(list(map(int, sys.stdin.readline().strip().split())))
+
+answer = 0
+K = int(input())
+for _ in range(K):
+    i, j, x, y = map(int, sys.stdin.readline().strip().split())
+    for a in range(i-1, x):
+        for b in range(j-1, y):
+            answer += arr[a][b]
+    print(answer)
+    answer = 0

--- a/jwj/week06/[9251] LCS.py
+++ b/jwj/week06/[9251] LCS.py
@@ -1,0 +1,25 @@
+'''
+* Author    : Jang Woo Jin
+* Date      : 2024.11.08(Fri)
+* Runtime   : 608 ms
+* Memory    : 55712 KB
+* Algorithm : Dynamic Programming
+'''
+
+import sys
+input = sys.stdin.readline
+
+String1 = input().strip()
+String2 = input().strip()
+lenString1 = len(String1)
+lenString2 = len(String2)
+
+dp = [[0] * (lenString1+1) for _ in range(lenString2+1)]
+
+for i in range(1, lenString2+1):
+    for j in range(1, lenString1+1):
+        if String2[i-1] == String1[j-1]:
+            dp[i][j] = dp[i-1][j-1] + 1
+        else:
+            dp[i][j] = max(dp[i-1][j], dp[i][j-1])
+print(dp[-1][-1])


### PR DESCRIPTION
- [x] **2차원 배열의 합(Silver 5)**

> 2차원 배열에서의 누적합 개념을 먼저 떠올리기보다 2중 반복문을 바로 사용해 문제를 해결했는데 이 방법보다 2차원 배열의 누적합을 이용해서 푸는 것이 더 좋을 것 같다고 느꼈습니다. 좋은 깨달음을 줬던 문제였습니다.

- [x] **정수 삼각형(Silver 1)** 

> 다이나믹 프로그래밍 문제였습니다. 빗변을 먼저 구한 후 내부에 대한 DP 점화식을 세워 문제를 해결할 수 있었습니다.

- [x] **연속합(Silver 2)**

> 1차원 배열에서의 누적합 문제였습니다. 현재까지의 합과 그 다음 요소를 포함시켰을 때 합을 비교하여 값을 갱신해나가면 쉽게 해결할 수 있는 문제였습니다.

- [x] **LCS(Gold 5)**

> LCS(Longest Common Subsequence) 문제였습니다. 각 문자열의 알파벳으로 구성된 2차원 배열을 만들고 시작합니다. 만약 두 문자열의 같은 알파벳이 나타난다면 모두의 부분 수열의 길이가 1만큼 증가하는 것이고 그게 아니라면 두 문자열 중에서 긴 부분 수열의 길이를 넣어주면 됩니다. 

해당 문제는 관련 알고리즘 포스팅이 잘 된 것이 있어서 남겨놓습니다.

[LCS](https://velog.io/@emplam27/%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-%EA%B7%B8%EB%A6%BC%EC%9C%BC%EB%A1%9C-%EC%95%8C%EC%95%84%EB%B3%B4%EB%8A%94-LCS-%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-Longest-Common-Substring%EC%99%80-Longest-Common-Subsequence)

- [x] **점수따먹기(Gold 4)**

> 2차원 배열에서의 누적합 문제였습니다. 2차원 배열에서의 누적합을 구할 때 `[i][j]`의 요소가 나타내는 의미는  `[0][0] ~ [i][j]` 까지의 합을 계산한 것을 말합니다. 이런 방식으로 누적합을 계산한 다음 부분 행렬을 잡아 부분 행렬의 값이 가장 큰 경우를 출력하라고 했으므로 누적합 2차원 배열에서 2중 반복문, 그리고 부분 행렬(역시 2차원 배열)에서 2중 반복문, 따라서 4중 반복문을 통해 부분 행렬의 최댓값과 초기값을 비교하여 부분 행렬의 최댓값을 구하면 됩니다.